### PR TITLE
Allow creation of unassigned Todos

### DIFF
--- a/lib/logan/todo.rb
+++ b/lib/logan/todo.rb
@@ -18,7 +18,7 @@ module Logan
       {
         :content => @content,
         :due_at => @due_at,
-        :assignee => @assignee.to_hash
+        :assignee => @assignee.blank? ? nil : @assignee.to_hash
       }.to_json
     end
     
@@ -26,7 +26,7 @@ module Logan
       { 
         :content => @content, 
         :due_at => @due_at,
-        :assignee => @assignee.to_hash,
+        :assignee => @assignee.blank? ? nil : @assignee.to_hash,
         :completed => @completed
       }.to_json
     end


### PR DESCRIPTION
Hi, 

If you try to create a todo record without setting the assignee field, bad things happen (nil reference).  This fixes that & lets you create a todo without assigning it.

Cheers,

Rick
